### PR TITLE
Updating README to change usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This library contains both basic convenience functions such as `readToEnd`, `con
 ## Usage
 
 ```bash
-npm install --save web-stream-tools
+npm install --save @openpgp/web-stream-tools
 ```
 
 ```js
-import stream from 'web-stream-tools';
+import * as stream from '@openpgp/web-stream-tools';
 ```
 
 ## Documentation


### PR DESCRIPTION
I am not 100% sure if this is correct, but it does work for me.

The current instructions result in having version 0.0.1 installed. These instructions will have the current (0.0.8) version installed.