### PR TITLE
TS: fix definitions to have `ReadableStream` compatible with `WebStream`, add tests

### DIFF
--- a/.github/workflows/test-type-definitions.yml
+++ b/.github/workflows/test-type-definitions.yml
@@ -1,0 +1,21 @@
+name: Types
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Test type definitions
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '15'
+    - run: npm ci
+    - run: npm run test-type-definitions

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+test/typescript-definitions.js
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,12 @@
         }
       }
     },
+    "@types/node": {
+      "version": "17.0.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
+      "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -121,6 +127,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "graceful-fs": {
@@ -188,6 +200,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,14 @@
     "web-streams-polyfill": "~3.0.3"
   },
   "devDependencies": {
-    "@openpgp/jsdoc": "^3.6.4"
+    "@openpgp/jsdoc": "^3.6.4",
+    "@types/node": "^17.0.18",
+    "esm": "^3.2.25",
+    "typescript": "^4.5.5"
   },
   "scripts": {
+    "test-type-definitions": "tsc test/typescript-definitions.ts && node --require esm test/typescript-definitions.js",
+    "test": "npm run test-type-definitions",
     "docs": "jsdoc --configure .jsdocrc.js --destination docs --readme README.md lib",
     "preversion": "rm -rf docs",
     "version": "npm run docs && git add -A docs",

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -20,4 +20,3 @@ import { WebStream, NodeStream, readToEnd } from '../';
   console.error(e);
   process.exit(1);
 });
- 

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -1,0 +1,23 @@
+import * as assert from 'assert';
+import { Readable as NodeReadableStream } from 'stream';
+import { ReadableStream as WebReadableStream } from 'web-streams-polyfill';
+import { WebStream, NodeStream, readToEnd } from '../';
+
+(async () => {
+ 
+  const nodeStream: NodeStream<string> = new NodeReadableStream();
+  assert(nodeStream instanceof NodeReadableStream);
+  // @ts-expect-error detect type parameter mismatch
+  const webStream: WebStream<string> = new ReadableStream<Uint8Array>();
+  assert(webStream instanceof WebReadableStream);
+
+  await readToEnd(new Uint8Array([1])) as Uint8Array;
+  await readToEnd(new Uint8Array([1]), _ => _) as Uint8Array[];
+
+  console.log('TypeScript definitions are correct');
+})().catch(e => {
+  console.error('TypeScript definitions tests failed by throwing the following error');
+  console.error(e);
+  process.exit(1);
+});
+ 

--- a/web-stream-tools.d.ts
+++ b/web-stream-tools.d.ts
@@ -28,7 +28,7 @@ interface WebStream<T extends Data> { // copied+simplified version of ReadableSt
   getReader(): ReadableStreamInternals.ReadableStreamDefaultReader<T>;
 }
 
-interface NodeStream<T extends Data> { // copied+simplified version of ReadableStream from @types/node/index.d.ts
+interface NodeStream<T extends Data> extends AsyncIterable<T> { // copied+simplified version of ReadableStream from @types/node/index.d.ts
   readable: boolean; pipe: Function; unpipe: Function; wrap: Function; setEncoding(encoding: string): this; pause(): this; resume(): this;
   isPaused(): boolean; unshift(chunk: string | Uint8Array): void;
   read(size?: number): T;

--- a/web-stream-tools.d.ts
+++ b/web-stream-tools.d.ts
@@ -2,25 +2,39 @@
 // Contributors:
 // - Flowcrypt a.s. <human@flowcrypt.com>
 
-declare module "@openpgp/web-stream-tools" {
-    type Data = Uint8Array | string;
-
-    interface BaseStream<T extends Data> extends AsyncIterable<T> { }
-
-    interface WebStream<T extends Data> extends BaseStream<T> { // copied+simplified version of ReadableStream from lib.dom.d.ts
-      readonly locked: boolean; getReader: Function; pipeThrough: Function; pipeTo: Function; tee: Function;
-      cancel(reason?: any): Promise<void>;
-    }
-
-    interface NodeStream<T extends Data> extends BaseStream<T> { // copied+simplified version of ReadableStream from @types/node/index.d.ts
-      readable: boolean; pipe: Function; unpipe: Function; wrap: Function;
-      read(size?: number): string | Uint8Array; setEncoding(encoding: string): this; pause(): this; resume(): this;
-      isPaused(): boolean; unshift(chunk: string | Uint8Array): void;
-    }
-
-    type Stream<T extends Data> = WebStream<T> | NodeStream<T>;
-
-    type MaybeStream<T extends Data> = T | Stream<T>;
-
-    export function readToEnd<T extends Data>(input: MaybeStream<T>, concat?: (list: T[]) => T): Promise<T>;
+export namespace ReadableStreamInternals {
+  // copied+simplified version of ReadableStream from lib.dom.d.ts, needed to enforce type checks in WebStream below
+  interface ReadableStreamDefaultReadDoneResult {
+    done: true;
+    value?: undefined;
+  }
+  interface ReadableStreamDefaultReadValueResult<T> {
+    done: false;
+    value: T;
+  }
+  interface ReadableStreamDefaultReader<R = any> {
+    readonly closed: Promise<undefined>;
+    cancel(reason?: any): Promise<void>;
+    read(): Promise<ReadableStreamDefaultReadValueResult<R> | ReadableStreamDefaultReadDoneResult>;
+    releaseLock(): void;
+  }
 }
+
+type Data = Uint8Array | string;
+
+interface WebStream<T extends Data> { // copied+simplified version of ReadableStream from lib.dom.d.ts
+  readonly locked: boolean; pipeThrough: Function; pipeTo: Function; tee: Function;
+  cancel(reason?: any): Promise<void>;
+  getReader(): ReadableStreamInternals.ReadableStreamDefaultReader<T>;
+}
+
+interface NodeStream<T extends Data> { // copied+simplified version of ReadableStream from @types/node/index.d.ts
+  readable: boolean; pipe: Function; unpipe: Function; wrap: Function; setEncoding(encoding: string): this; pause(): this; resume(): this;
+  isPaused(): boolean; unshift(chunk: string | Uint8Array): void;
+  read(size?: number): T;
+}
+
+type Stream<T extends Data> = WebStream<T> | NodeStream<T>;
+type MaybeStream<T extends Data> = T | Stream<T>;
+
+export function readToEnd<T extends Data, R extends any = T>(input: MaybeStream<T>, join?: (chunks: T[]) => R): Promise<R>;


### PR DESCRIPTION
Changes:
- update `WebStream` definition so that type inference works when using a `ReadableStream`. Specifically, we cannot rely on the `AsyncIterable` interface, because ReadableStreams are not currently implemented by all browsers as including the necessary properties.
- generalise `readToEnd` definition to support `join` function with arbitrary output type
- add TS tests to CI 