### PR TITLE
Fix error handling in `transform` for `ArrayStream`s

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -265,15 +265,19 @@ function transform(input, process = () => undefined, finish = () => undefined) {
   if (isArrayStream(input)) {
     const output = new ArrayStream();
     (async () => {
-      const data = await readToEnd(input);
-      const result1 = process(data);
-      const result2 = finish();
-      let result;
-      if (result1 !== undefined && result2 !== undefined) result = concat([result1, result2]);
-      else result = result1 !== undefined ? result1 : result2;
       const writer = getWriter(output);
-      await writer.write(result);
-      await writer.close();
+      try {
+        const data = await readToEnd(input);
+        const result1 = process(data);
+        const result2 = finish();
+        let result;
+        if (result1 !== undefined && result2 !== undefined) result = concat([result1, result2]);
+        else result = result1 !== undefined ? result1 : result2;
+        await writer.write(result);
+        await writer.close();
+      } catch (e) {
+        await writer.abort(e);
+      }
     })();
     return output;
   }


### PR DESCRIPTION
The anonymous async function lacked error handling and could have crashed recent NodeJS versions with an unhandled rejection.

Fixes openpgpjs#1454