### PR TITLE
CI: setup Dependabot to detect TS updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      # Allow updates for TS
+      - dependency-name: "typescript"
+    versioning-strategy: increase
+


### PR DESCRIPTION
This is intended to monitor whether a new TS release is introducing breaking type changes