### PR TITLE
Use '.js' endings in import statements

### DIFF
--- a/lib/node-conversions.js
+++ b/lib/node-conversions.js
@@ -1,5 +1,5 @@
-import { isNode } from './util';
-import * as streams from './streams';
+import { isNode } from './util.js';
+import * as streams from './streams.js';
 
 const NodeBuffer = isNode && require('buffer').Buffer;
 const NodeReadableStream = isNode && require('stream').Readable;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,5 +1,5 @@
-import * as streams from './streams';
-import { isUint8Array } from './util';
+import * as streams from './streams.js';
+import { isUint8Array } from './util.js';
 
 const doneReadingSet = new WeakSet();
 const externalBuffer = Symbol('externalBuffer');

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,7 +1,7 @@
-import { isNode, isStream, isArrayStream, isUint8Array, concatUint8Array } from './util';
-import { nodeToWeb, webToNode } from './node-conversions';
-import { Reader, externalBuffer } from './reader';
-import { ArrayStream, Writer } from './writer';
+import { isNode, isStream, isArrayStream, isUint8Array, concatUint8Array } from './util.js';
+import { nodeToWeb, webToNode } from './node-conversions.js';
+import { Reader, externalBuffer } from './reader.js';
+import { ArrayStream, Writer } from './writer.js';
 
 const NodeBuffer = isNode && require('buffer').Buffer;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,4 @@
-import { isArrayStream } from './writer';
+import { isArrayStream } from './writer.js';
 
 const isNode = typeof globalThis.process === 'object' &&
   typeof globalThis.process.versions === 'object';


### PR DESCRIPTION
We're having problems loading the script as module the way it is now, so we have to patch it before use.
As I understand, it is current standard to have `.js` explicitly specified in `import` statements.
