### PR TITLE
Support for Firefox sandboxed Uint8Array

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -32,7 +32,7 @@ function isStream(input) {
  * @returns {Boolean}
  */
 function isUint8Array(input) {
-  return Uint8Array.prototype.isPrototypeOf(input);
+  return Uint8Array.prototype.isPrototypeOf(input) || globalThis.Uint8Array.prototype.isPrototypeOf(input);
 }
 
 /**


### PR DESCRIPTION
When loading OpenPGP.js 5.7.0 in a web content script in Firefox 112, it turned out
`Uint8Array.prototype !== globalThis.Uint8Array.prototype`, as a result `Key.armor()` fails on a parsed key.
This patch fixes the problem.