### PR TITLE
Fix (temporary): stream.cancel race condition

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -522,7 +522,10 @@ async function readToEnd(input, join=concat) {
 async function cancel(input, reason) {
   if (isStream(input)) {
     if (input.cancel) {
-      return input.cancel(reason);
+      const cancelled = await input.cancel(reason);
+      // the stream is not always cancelled at this point, so we wait some more
+      await new Promise(setTimeout);
+      return cancelled;
     }
     if (input.destroy) {
       input.destroy(reason);


### PR DESCRIPTION
Stream was not always cancelled when `input.cancel`'s promise resolved; the problem was observed in the OpenPGP.js tests on firefox, as part of the changes in https://github.com/openpgpjs/openpgpjs/pull/1645.

We could repro the problem also using lib versions < 0.0.12, namely before the changes in https://github.com/openpgpjs/web-stream-tools/commit/9bdfe7917b583eb53b51062b85cd750062793c9c.

This is a temporary fix: since stream cancellation is not a performance-sensitive operation, we've opted to add a small timeout to the promise. We'll have to investigate why the issue comes up in the first place.

