### PR TITLE
transformWithCancel: fix race condition in cancellation

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -220,6 +220,7 @@ function transformRaw(input, options) {
  */
 function transformWithCancel(customCancel) {
   let pulled = false;
+  let cancelled = false;
   let backpressureChangePromiseResolve, backpressureChangePromiseReject;
   let outputController;
   return {
@@ -235,17 +236,20 @@ function transformWithCancel(customCancel) {
         }
       },
       async cancel(reason) {
+        cancelled = true;
         if (customCancel) {
           await customCancel(reason);
         }
         if (backpressureChangePromiseReject) {
           backpressureChangePromiseReject(reason);
         }
-        outputController.error(reason);
       }
     }, {highWaterMark: 0}),
     writable: new WritableStream({
       write: async function(chunk) {
+        if (cancelled) {
+          throw new Error('Stream is cancelled');
+        }
         outputController.enqueue(chunk);
         if (!pulled) {
           await new Promise((resolve, reject) => {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -218,9 +218,9 @@ function transformRaw(input, options) {
  * @param {Function} cancel
  * @returns {TransformStream}
  */
-function transformWithCancel(cancel) {
+function transformWithCancel(customCancel) {
   let pulled = false;
-  let backpressureChangePromiseResolve;
+  let backpressureChangePromiseResolve, backpressureChangePromiseReject;
   let outputController;
   return {
     readable: new ReadableStream({
@@ -234,16 +234,26 @@ function transformWithCancel(cancel) {
           pulled = true;
         }
       },
-      cancel
+      async cancel(reason) {
+        if (customCancel) {
+          await customCancel(reason);
+        }
+        if (backpressureChangePromiseReject) {
+          backpressureChangePromiseReject(reason);
+        }
+        outputController.error(reason);
+      }
     }, {highWaterMark: 0}),
     writable: new WritableStream({
       write: async function(chunk) {
         outputController.enqueue(chunk);
         if (!pulled) {
-          await new Promise(resolve => {
+          await new Promise((resolve, reject) => {
             backpressureChangePromiseResolve = resolve;
+            backpressureChangePromiseReject = reject;
           });
           backpressureChangePromiseResolve = null;
+          backpressureChangePromiseReject = null;
         } else {
           pulled = false;
         }


### PR DESCRIPTION
Relevant for e.g.`passiveClone`s.
Fixes test failure in: https://github.com/openpgpjs/openpgpjs/pull/1762 .