### PR TITLE
Add `consumeToEnd` convenience function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,6 +13,8 @@ export function readToEnd<T extends Data, JoinFn extends (chunks: T[]) => any = 
   join?: JoinFn
 ): Promise<ReturnType<JoinFn>>;
 
+export function consumeToEnd<T extends Data>(input: MaybeStream<T>): Promise<undefined>;
+
 export function toStream<T extends Data, InputType extends MaybeStream<T>>(
   input: InputType
 ): InputType extends T ? Stream<InputType> : InputType;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -204,4 +204,16 @@ Reader.prototype.readToEnd = async function(join=streams.concat) {
   return join(result);
 };
 
+/**
+ * Consume the entire stream and wait until it ends.
+ * @async
+ */
+Reader.prototype.consumeToEnd = async function() {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done } = await this.read();
+    if (done) break;
+  }
+};
+
 export { Reader, externalBuffer };

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -500,6 +500,20 @@ async function readToEnd(input, join=concat) {
 }
 
 /**
+ * Consume a stream to the end. Throws if the input stream errors.
+ * @param {ReadableStream|Uint8array|String} input
+ * @async
+ */
+async function consumeToEnd(input) {
+  if (isArrayStream(input)) {
+    return input.consumeToEnd();
+  }
+  if (isStream(input)) {
+    return getReader(input).consumeToEnd();
+  }
+}
+
+/**
  * Cancel a stream.
  * @param {ReadableStream|Uint8array|String} input
  * @param {Any} reason
@@ -576,6 +590,7 @@ export {
   passiveClone,
   slice,
   readToEnd,
+  consumeToEnd,
   cancel,
   fromAsync
 };

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -40,6 +40,10 @@ ArrayStream.prototype.readToEnd = async function(join) {
   return result;
 };
 
+ArrayStream.prototype.consumeToEnd = async function() {
+  await this[doneWritingPromise];
+};
+
 ArrayStream.prototype.clone = function() {
   const clone = new ArrayStream();
   clone[doneWritingPromise] = this[doneWritingPromise].then(() => {


### PR DESCRIPTION
Similar to `readToEnd`, but discard the data.