### PR TITLE
Release read lock in `parse` after parsing function returns/throws

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -309,12 +309,13 @@ function transformPair(input, fn) {
  *   for cancelation.
  * @param {ReadableStream|Uint8array|String} input
  * @param {Function} fn
- * @returns {Any} the return value of fn()
+ * @returns {Promise<Any>} the return value of fn()
  */
-function parse(input, fn) {
+async function parse(input, fn) {
   let returnValue;
+  let reader;
   const transformed = transformPair(input, (readable, writable) => {
-    const reader = getReader(readable);
+    reader = getReader(readable);
     reader.remainder = () => {
       reader.releaseLock();
       pipe(readable, writable);
@@ -322,7 +323,11 @@ function parse(input, fn) {
     };
     returnValue = fn(reader);
   });
-  return returnValue;
+  try {
+    return await returnValue;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 /**


### PR DESCRIPTION
Enable using the input stream after parsing succeeds/fails.