### PR TITLE
Fix: Convert Uint8Array to string properly when readLine

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -94,8 +94,12 @@ Reader.prototype.cancel = function(reason) {
 Reader.prototype.readLine = async function() {
   let buffer = [];
   let returnVal;
+  const textDecoder = new TextDecoder();
   while (!returnVal) {
     let { done, value } = await this.read();
+    if (value instanceof Uint8Array) {
+        value = textDecoder.decode(value);
+    }
     value += '';
     if (done) {
       if (buffer.length) return streams.concat(buffer);


### PR DESCRIPTION
This pr converts an Uint8Array to string properly.
```javascript
const u8 = new Uint8Array([72, 69, 76, 76, 79]);
u8.toString(); // return: '72,69,76,76,79'

const decoder = new TextDecoder();
decoder.decode(u8); // return: 'HELLO'
```